### PR TITLE
Update pillow min version to fix libwebp CVE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.8
-    - uses: pre-commit/action@v2.0.0
+        python-version: 3.11
+    - uses: pre-commit/action@v3.0.0
 
   test:
     name: "Test - ${{ matrix.os }}, py ${{ matrix.python-version }}, Sphinx ${{ matrix.sphinx }}"
@@ -20,12 +20,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, windows, macos]
-        python-version: ['3.7', '3.8', '3.9']
-        sphinx: ['2', '3', '4']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        sphinx: ['2', '3', '4', '5', '6', '7']
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dev dependencies
@@ -50,13 +50,13 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.8'
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
@@ -23,7 +23,7 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         sphinx: ['2', '3', '4', '5', '6', '7']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
@@ -50,7 +50,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
         sphinx: ['2', '3', '4', '5', '6', '7']
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
 sphinx
 beautifulsoup4==4.9.3
 soupsieve==2.2.1; python_version >= "3.6"
-pillow==8.3.1; python_version >= "3.6"
+pillow==10.0.1; python_version >= "3.8"

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setuptools.setup(
     install_requires=[
         "sphinx>=2.0",
         "beautifulsoup4>=4",
-        "pillow>=8",
+        "pillow>=10.0.1",
         "tinycss2>=1.1.1",
     ],
     classifiers=[
@@ -37,9 +37,11 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Programming Language :: Python",
         "Topic :: Documentation :: Sphinx",
         "Topic :: Documentation",
@@ -47,6 +49,6 @@ setuptools.setup(
         "Topic :: Text Processing",
         "Topic :: Utilities",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.8",
     include_package_data=True,
 )


### PR DESCRIPTION
Bump min python version to 3.8 to match Pillow requirements
Update CI test matrix for latest python and sphinx versions
Update actions versions